### PR TITLE
Fixing list insert error under BSD sed

### DIFF
--- a/liblist.sh
+++ b/liblist.sh
@@ -75,7 +75,9 @@ list_push_back () {
 #
 list_insert () {
     test "$#" -ne 3 && return 1
-    i="$2"; [ "$i" != '$' ] &&  i=$((i+1)); echo "$3" | sed "${i}i${1}"
+    i="$2"; [ "$i" != '$' ] &&  i=$((i+1)); echo "$3" | sed "${i}i\\
+${1}
+"
 }
 
 ##

--- a/liblist_unsafe.sh
+++ b/liblist_unsafe.sh
@@ -79,7 +79,9 @@ list_push_back () {
 #
 list_insert () {
     test "$#" -ne 3 && return 1; i="$3"; [ "$i" != '$' ] &&  i=$((i+1))
-    eval "$1=\"\$(echo \"\$$1\" | sed \"${i}i${2}\")\""
+    eval "$1=\"\$(echo \"\$$1\" | sed \"${i}i\\\\
+${2}
+\")\""
 }
 
 ##

--- a/tests/test_freebsd.sh
+++ b/tests/test_freebsd.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Test to make sure BSD sed and GNU sed work for
+# list insertion. Assumes that both version of
+# sed are present in PATH
+
+set -e
+
+. ./liblist.sh
+
+
+insert_test() {
+  type sed
+  lst="$(list 'C' 'A' 'B')"
+  lst_expected="$(list 'D' 'C' 'A' 'B')"
+
+  lst="$(list_insert "D" 0 "$lst")"
+
+  if [ "$lst" == "$lst_expected" ]; then
+    echo "test: insert pass"
+    return 0
+  else
+    echo "test: insert fail"
+    return 1
+  fi
+}
+
+insert_test_gsed() {
+  # Keep gsed override wrapped
+  sed() {
+      gsed "$@"
+  }
+  insert_test
+  # Make sure this doesnt pollute other tests
+  unset -f sed
+}
+
+insert_test
+echo '--------------------------'
+insert_test_gsed

--- a/tests/test_unsafe_freebsd.sh
+++ b/tests/test_unsafe_freebsd.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Test to make sure BSD sed and GNU sed work for
+# list insertion. Assumes that both version of
+# sed are present in PATH
+
+set -e
+
+. ./liblist_unsafe.sh
+
+
+insert_test() {
+  type sed
+  lst="$(list 'C' 'A' 'B')"
+  lst_expected="$(list 'D' 'C' 'A' 'B')"
+
+  list_insert lst "D" 0
+
+  if [ "$lst" == "$lst_expected" ]; then
+    echo "test: insert pass"
+    return 0
+  else
+    echo "test: insert fail"
+    return 1
+  fi
+}
+
+insert_test_gsed() {
+  # Keep gsed override wrapped
+  sed() {
+      gsed "$@"
+  }
+  # Make sure this doesnt pollute other tests
+  insert_test
+  unset -f sed
+}
+
+insert_test
+echo '--------------------------'
+insert_test_gsed


### PR DESCRIPTION
## Description

This was related to the FreeBSD port for `mons` and the issue opened up in the portstree bugzilla: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=248632

BSD sed was unable to correctly leverage `i` command resulting in the following output when running `mons` on `master` 375bbba3aa700c8b3b33645a7fb70605c8b0ff0c:
```
 $ ./mons
sed: 1: "1iLVDS-1": command i expects \ followed by text
Monitors: 0
Mode: primary
```

The following change was initially suggested by @kevans91 here: https://github.com/Ventto/mons/issues/30#issuecomment-674335403 but I did some more testing to get the following to be compliant for both GNU and BSD versions of sed.

## Tests

I have added appropriate tests for both the `libshlist` and `libshlist_unsafe` variations.
```
$ sh tests/test_freebsd.sh 
sed is /usr/bin/sed
test: insert pass
--------------------------
sed is a shell function
test: insert pass
```
```
$ sh tests/test_unsafe_freebsd.sh 
sed is /usr/bin/sed
test: insert pass
--------------------------
sed is a shell function
test: insert pass
```

As for `mons` this also fixes the original error. I do have an issue with how `command -pv xrandr` is working and have to modify it to `command -v xrandr` but Ill open that issue in `mons` for discussion:
```
$ ./mons
Monitors:        2
Mode: primary
0:*  LVDS-1   (enabled) 
```